### PR TITLE
[feat] logout API 구현

### DIFF
--- a/src/main/java/kr/co/preq/domain/auth/controller/AuthController.java
+++ b/src/main/java/kr/co/preq/domain/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package kr.co.preq.domain.auth.controller;
 
 import javax.validation.Valid;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import kr.co.preq.domain.auth.dto.AuthRequestDto;
 import kr.co.preq.domain.auth.dto.AuthResponseDto;
+import kr.co.preq.domain.auth.dto.LogoutRequestDto;
 import kr.co.preq.domain.auth.dto.TokenRequestDto;
 import kr.co.preq.domain.auth.service.AuthService;
 import kr.co.preq.global.common.util.jwt.TokenDto;
@@ -35,5 +37,11 @@ public class AuthController {
 	public ApiResponse<TokenDto> refresh(@RequestBody @Valid TokenRequestDto tokenRequestDto) {
 		TokenDto response = authService.reissue(tokenRequestDto);
 		return ApiResponse.success(SuccessCode.TOKEN_REISSUE_SUCCESS, response);
+	}
+
+	@PostMapping("/logout")
+	public ApiResponse<Object> logout(@RequestBody @Valid LogoutRequestDto logoutRequestDto) {
+		authService.logout(logoutRequestDto);
+		return ApiResponse.success(SuccessCode.LOGOUT_SUCCESS, null);
 	}
 }

--- a/src/main/java/kr/co/preq/domain/auth/dto/LogoutRequestDto.java
+++ b/src/main/java/kr/co/preq/domain/auth/dto/LogoutRequestDto.java
@@ -1,0 +1,24 @@
+package kr.co.preq.domain.auth.dto;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LogoutRequestDto {
+	@NotBlank
+	private String accessToken;
+
+	@NotBlank
+	private String refreshToken;
+
+	public static LogoutRequestDto of(String accessToken, String refreshToken) {
+		LogoutRequestDto logoutRequestDto = new LogoutRequestDto();
+		logoutRequestDto.accessToken = accessToken;
+		logoutRequestDto.refreshToken = refreshToken;
+		return logoutRequestDto;
+	}
+}

--- a/src/main/java/kr/co/preq/global/common/util/jwt/TokenProvider.java
+++ b/src/main/java/kr/co/preq/global/common/util/jwt/TokenProvider.java
@@ -95,9 +95,8 @@ public class TokenProvider {
 	}
 
 	public boolean isLogout(String accessToken) {
-		// String data = redisUtil.getData(RedisUtil.PREFIX_LOGOUT + accessToken);
-		// return data != null;
-		return false;
+		String data = redisUtil.getData(RedisUtil.PREFIX_LOGOUT + accessToken);
+		return data != null;
 	}
 
 	private Claims parseClaims(String accessToken) {


### PR DESCRIPTION
## 📌 Related Issue

- Closed #43 

## 🧾 Describe your changes
logout API 구현
- 로그아웃 시 access token 만료 처리 -> 로그아웃된 토큰이라고 redis에 저장 -> 더 이상 유효하지 않은 토큰
- refresh token은 redis에 저장되어 있던 값 삭제 -> 더 이상 유효하지 않은 토큰

## 📚 Etc

